### PR TITLE
add missing dependency latexmk

### DIFF
--- a/base-pdf/Dockerfile
+++ b/base-pdf/Dockerfile
@@ -2,6 +2,7 @@ FROM tk0miya/sphinx-base:latest
 MAINTAINER Sphinx Team <https://github.com/sphinx-doc/sphinx>
 
 RUN apt-get install -y \
+      latexmk \
       lmodern \
       texlive-latex-recommended \
       texlive-latex-extra \


### PR DESCRIPTION
I got a `latexmk: Command not found` error and found out `latexmk` was added in https://github.com/sphinx-doc/sphinx/pull/3082